### PR TITLE
Add defaultdict to imports

### DIFF
--- a/pyscisci/metrics/raostirling.py
+++ b/pyscisci/metrics/raostirling.py
@@ -11,6 +11,8 @@ import numpy as np
 
 import scipy.sparse as spsparse
 
+from collections import defaultdict
+
 from sklearn.metrics import pairwise_distances
 from sklearn.preprocessing import normalize
 


### PR DESCRIPTION
Hi Alex,

Small fix in `raostirling.py`: `defaultdict` is used when normalization of publications' fields is `False`, but it was never imported.

- Rodrigo