### PR TITLE
Typo in the disruption index calculation when windows is provided

### DIFF
--- a/pyscisci/methods/disruption.py
+++ b/pyscisci/methods/disruption.py
@@ -63,7 +63,7 @@ def disruption_index(pub2ref, focus_pub_ids = None, cite_window = None, ref_wind
         citation_groups = pub2ref.groupby('CitedPublicationId', sort = False)['CitingPublicationId']
     else:
         cite_sub = [ ((y1-y2) >= cite_window[0] and (y1-y2) <=cite_window[1]) for y1,y2 in pub2ref[['CitingYear', 'CitedYear']].values]
-        citation_groups = pub2ref.loc[cite_sub].groupby('CitingPublicationId', sort = False)['CitedPublicationId']
+        citation_groups = pub2ref.loc[cite_sub].groupby('CitedPublicationId', sort = False)['CitingPublicationId']
 
     if focus_pub_ids is None:
         if cite_window is None:


### PR DESCRIPTION
I believe there is an issue with the current code used to calculate disruption, in particular there is a typo regarding the cited and citing entries in when getting the citation groups if a time window is provided as parameter. The entries are reverted.

```python
citation_groups = pub2ref.loc[cite_sub].groupby('CitingPublicationId', sort = False)['CitedPublicationId']
```
was supposed to be:
```python
citation_groups = pub2ref.loc[cite_sub].groupby('CitedPublicationId', sort = False)['CitingPublicationId']
```
in line 66.

This PR fixes that issue.

